### PR TITLE
Remove `order` query param from manual_journals request (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.3
+  * Adds a workaround for a Xero bug to allow pagination to function properly in the `manual_journals` stream [#104](https://github.com/singer-io/tap-xero/pull/104)
+
 ## 2.2.2
   * Changes the endpoint used for check_platform_access from `Contacts` to `Currencies` [#98](https://github.com/singer-io/tap-xero/pull/98)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-xero",
-      version="2.2.2",
+      version="2.2.3",
       description="Singer.io tap for extracting data from the Xero API",
       author="Stitch",
       url="http://singer.io",


### PR DESCRIPTION
* Remove `order` query param from manual_journals request

* Disable `consider-using-generator` pylint warning

* Bump to v2.2.3

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
